### PR TITLE
All Photos: server‑side date sort + city/year filters (no full fetch)

### DIFF
--- a/Immich Gallery/Services/AssetProvider.swift
+++ b/Immich Gallery/Services/AssetProvider.swift
@@ -41,6 +41,8 @@ struct AssetProviderFactory {
 protocol AssetProvider {
     func fetchAssets(page: Int, limit: Int) async throws -> SearchResult
     func fetchRandomAssets(limit: Int) async throws -> SearchResult
+    func fetchAllCities() async throws -> [String]
+    func fetchAllYears() async throws -> [Int]
 }
 
 class AlbumAssetProvider: AssetProvider {
@@ -122,6 +124,26 @@ class AlbumAssetProvider: AssetProvider {
             total: assets.count,
             nextPage: nil
         )
+    }
+
+    func fetchAllCities() async throws -> [String] {
+        let assets = try await loadAlbumAssets()
+        let cities = assets.compactMap { asset in
+            if let city = asset.exifInfo?.city, !city.isEmpty {
+                return city
+            }
+            return nil
+        }
+        return Array(Set(cities)).sorted()
+    }
+
+    func fetchAllYears() async throws -> [Int] {
+        let assets = try await loadAlbumAssets()
+        let years = assets.compactMap { asset -> Int? in
+            let yearString = asset.localDateTime.prefix(4)
+            return Int(yearString)
+        }
+        return Array(Set(years)).sorted(by: >)
     }
     
     private func sortAssets(_ assets: [ImmichAsset]) -> [ImmichAsset] {
@@ -227,5 +249,13 @@ class GeneralAssetProvider: AssetProvider {
                 limit: limit
             )
         }
+    }
+
+    func fetchAllCities() async throws -> [String] {
+        return try await assetService.fetchAllCities()
+    }
+
+    func fetchAllYears() async throws -> [Int] {
+        return try await assetService.fetchAllYears()
     }
 }

--- a/Immich Gallery/Services/AssetService.swift
+++ b/Immich Gallery/Services/AssetService.swift
@@ -19,6 +19,8 @@ class AssetService: ObservableObject {
         let sortOrder = isAllPhotos 
             ? UserDefaults.standard.allPhotosSortOrder
             : (UserDefaults.standard.string(forKey: "assetSortOrder") ?? "desc")
+        let selectedCity = isAllPhotos ? UserDefaults.standard.allPhotosFilterCity : city
+        let selectedYear = isAllPhotos ? UserDefaults.standard.allPhotosFilterYear : nil
         var searchRequest: [String: Any] = [
             "page": page,
             "withPeople": true,
@@ -42,8 +44,12 @@ class AssetService: ObservableObject {
         if isFavorite {
             searchRequest["isFavorite"] = true
         }
-        if let city = city {
-            searchRequest["city"] = city
+        if let selectedCity {
+            searchRequest["city"] = selectedCity
+        }
+        if let selectedYear, let yearRange = makeYearRange(year: selectedYear) {
+            searchRequest["takenAfter"] = yearRange.start
+            searchRequest["takenBefore"] = yearRange.end
         }
         if let folderPath = folderPath, !folderPath.isEmpty {
             searchRequest["originalPath"] = folderPath
@@ -61,6 +67,44 @@ class AssetService: ObservableObject {
             total: result.assets.total,
             nextPage: result.assets.nextPage
         )
+    }
+
+    func fetchAllCities() async throws -> [String] {
+        let assets: [ImmichAsset] = try await networkService.makeRequest(
+            endpoint: "/api/search/cities",
+            method: .GET,
+            responseType: [ImmichAsset].self
+        )
+
+        let cities = assets.compactMap { asset in
+            if let city = asset.exifInfo?.city, !city.isEmpty {
+                return city
+            }
+            return nil
+        }
+        
+        return Array(Set(cities)).sorted()
+    }
+
+    func fetchAllYears() async throws -> [Int] {
+        let endpoint = "/api/timeline/buckets?isTrashed=false"
+
+        struct Bucket: Codable {
+            let timeBucket: String
+        }
+
+        let response: [Bucket] = try await networkService.makeRequest(
+            endpoint: endpoint,
+            method: .GET,
+            responseType: [Bucket].self
+        )
+
+        let years = response.compactMap { bucket in
+            let yearString = bucket.timeBucket.prefix(4)
+            return Int(yearString)
+        }
+
+        return Array(Set(years)).sorted(by: >)
     }
     
     /// Fetches assets using slideshow configuration
@@ -172,6 +216,22 @@ class AssetService: ObservableObject {
         }
         
         return nil
+    }
+
+    private func makeYearRange(year: Int) -> (start: String, end: String)? {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+
+        guard let startDate = calendar.date(from: DateComponents(year: year, month: 1, day: 1)),
+              let endDate = calendar.date(from: DateComponents(year: year + 1, month: 1, day: 1)) else {
+            return nil
+        }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+
+        return (formatter.string(from: startDate), formatter.string(from: endDate))
     }
 
     func loadVideoURL(asset: ImmichAsset) async throws -> URL {

--- a/Immich Gallery/Views/AssetGridView.swift
+++ b/Immich Gallery/Views/AssetGridView.swift
@@ -12,6 +12,7 @@ struct AssetGridView: View {
     @ObservedObject var authService: AuthenticationService
     @ObservedObject private var thumbnailCache = ThumbnailCache.shared
     let assetProvider: AssetProvider
+    @AppStorage("allPhotosSortOrder") private var allPhotosSortOrder = "desc"
     let albumId: String? // Optional album ID to filter assets
     let personId: String? // Optional person ID to filter assets
     let tagId: String? // Optional tag ID to filter assets
@@ -34,6 +35,10 @@ struct AssetGridView: View {
     @State private var hasMoreAssets = true
     @State private var loadMoreTask: Task<Void, Never>?
     @State private var showingSlideshow = false
+    @State private var showingFilterModal = false
+    @State private var showingSortModal = false
+    @State private var filterCity: String? = UserDefaults.standard.allPhotosFilterCity
+    @State private var filterYear: Int? = UserDefaults.standard.allPhotosFilterYear
     
     private let columns = [
         GridItem(.fixed(300), spacing: 50),
@@ -71,6 +76,10 @@ struct AssetGridView: View {
                 }
             } else if assets.isEmpty {
                 VStack {
+                    if isAllPhotos {
+                        allPhotosToolbar
+                            .padding(.bottom, 20)
+                    }
                     Image(systemName: "photo.on.rectangle.angled")
                         .font(.system(size: 60))
                         .foregroundColor(.gray)
@@ -82,6 +91,10 @@ struct AssetGridView: View {
                 }
             } else {
                 VStack {
+                    if isAllPhotos {
+                        allPhotosToolbar
+                            .padding(.bottom, 20)
+                    }
                     ScrollViewReader { proxy in
                         ScrollView {
                             LazyVGrid(columns: columns, spacing: 50) {
@@ -218,6 +231,21 @@ struct AssetGridView: View {
             print("Play pause tapped in AssetGridView - starting slideshow")
             startSlideshow()
         })
+        .sheet(isPresented: $showingFilterModal) {
+            FilterSettingsView(
+                assetProvider: assetProvider,
+                selectedCity: $filterCity,
+                selectedYear: $filterYear
+            ) {
+                applyFilters()
+            }
+        }
+        .sheet(isPresented: $showingSortModal) {
+            SortSettingsView(sortOrder: $allPhotosSortOrder) {
+                showingSortModal = false
+                loadAssets()
+            }
+        }
         .onAppear {
             print("Appared")
             if assets.isEmpty {
@@ -256,6 +284,33 @@ struct AssetGridView: View {
             startSlideshow()
         }
     }
+
+    private var allPhotosToolbar: some View {
+        HStack(spacing: 30) {
+            Spacer()
+
+            Button(action: { showingFilterModal = true }) {
+                let count = (filterCity != nil ? 1 : 0) + (filterYear != nil ? 1 : 0)
+                Label {
+                    Text("Filter \(count > 0 ? "(\(count))" : "")")
+                } icon: {
+                    Image(systemName: count > 0 ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
+                }
+            }
+            .buttonStyle(.bordered)
+
+            Button(action: { showingSortModal = true }) {
+                let orderLabel = allPhotosSortOrder == "asc" ? "Oldest" : "Newest"
+                Label {
+                    Text("Sort: Date Taken (\(orderLabel))")
+                } icon: {
+                    Image(systemName: "arrow.up.arrow.down")
+                }
+            }
+            .buttonStyle(.bordered)
+            .padding(.trailing, 60)
+        }
+    }
     
     private func loadAssets() {
         guard authService.isAuthenticated else {
@@ -291,6 +346,13 @@ struct AssetGridView: View {
                 }
             }
         }
+    }
+
+    private func applyFilters() {
+        UserDefaults.standard.allPhotosFilterCity = filterCity
+        UserDefaults.standard.allPhotosFilterYear = filterYear
+        showingFilterModal = false
+        loadAssets()
     }
     
     private func debouncedLoadMore() {
@@ -376,7 +438,9 @@ struct AssetGridView: View {
     }
     
     private func getEmptyStateTitle() -> String {
-        if personId != nil {
+        if isAllPhotos, (filterCity != nil || filterYear != nil) {
+            return "No Results for Filters"
+        } else if personId != nil {
             return "No Photos of Person"
         } else if albumId != nil {
             return "No Photos in Album"
@@ -386,7 +450,9 @@ struct AssetGridView: View {
     }
     
     private func getEmptyStateMessage() -> String {
-        if personId != nil {
+        if isAllPhotos, (filterCity != nil || filterYear != nil) {
+            return "Try adjusting your filter settings."
+        } else if personId != nil {
             return "This person has no photos"
         } else if albumId != nil {
             return "This album is empty"
@@ -424,4 +490,3 @@ struct AssetGridView: View {
         }
     }
 }
-

--- a/Immich Gallery/Views/FilterSettingsView.swift
+++ b/Immich Gallery/Views/FilterSettingsView.swift
@@ -1,0 +1,177 @@
+//
+//  FilterSettingsView.swift
+//  Immich Gallery
+//
+
+import SwiftUI
+
+struct FilterSettingsView: View {
+    let assetProvider: AssetProvider
+    @Binding var selectedCity: String?
+    @Binding var selectedYear: Int?
+    var onApply: () -> Void
+
+    @State private var localCity: String?
+    @State private var localYear: Int?
+    @State private var availableCities: [String] = []
+    @State private var availableYears: [Int] = []
+    @State private var isLoading = true
+
+    init(
+        assetProvider: AssetProvider,
+        selectedCity: Binding<String?>,
+        selectedYear: Binding<Int?>,
+        onApply: @escaping () -> Void
+    ) {
+        self.assetProvider = assetProvider
+        self._selectedCity = selectedCity
+        self._selectedYear = selectedYear
+        self.onApply = onApply
+        _localCity = State(initialValue: selectedCity.wrappedValue)
+        _localYear = State(initialValue: selectedYear.wrappedValue)
+    }
+
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .fill(.ultraThinMaterial)
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                VStack(spacing: 10) {
+                    Text("Filter Photos")
+                        .font(.system(size: 70, weight: .bold))
+                        .foregroundColor(.white)
+
+                    Text("Select options to narrow results")
+                        .font(.title3)
+                        .foregroundColor(.gray)
+                }
+                .padding(.top, 60)
+                .padding(.bottom, 30)
+
+                HStack(spacing: 40) {
+                    Button("Reset All") {
+                        localYear = nil
+                        localCity = nil
+                        selectedYear = nil
+                        selectedCity = nil
+                        onApply()
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button {
+                        selectedYear = localYear
+                        selectedCity = localCity
+                        onApply()
+                    } label: {
+                        Label("Apply Filters", systemImage: "checkmark.circle.fill")
+                            .padding(.horizontal, 40)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding(.bottom, 20)
+
+                if isLoading {
+                    ProgressView("Loading filters...")
+                        .scaleEffect(1.5)
+                        .padding(.top, 20)
+                } else {
+                    HStack(alignment: .top, spacing: 40) {
+                        filterColumn(
+                            title: "Years",
+                            items: availableYears.map { String($0) },
+                            selectedValue: localYear.map(String.init)
+                        ) { selection in
+                            localYear = selection.flatMap(Int.init)
+                        }
+
+                        filterColumn(
+                            title: "Cities",
+                            items: availableCities,
+                            selectedValue: localCity
+                        ) { selection in
+                            localCity = selection
+                        }
+                    }
+                    .padding(.horizontal, 60)
+                }
+
+                Spacer()
+            }
+        }
+        .task {
+            await loadData()
+        }
+    }
+
+    private func filterColumn(
+        title: String,
+        items: [String],
+        selectedValue: String?,
+        onSelect: @escaping (String?) -> Void
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text(title)
+                .font(.headline)
+                .foregroundColor(.white.opacity(0.6))
+                .padding(.leading, 20)
+
+            ScrollView {
+                VStack(spacing: 15) {
+                    filterButton(label: "All", isSelected: selectedValue == nil) {
+                        onSelect(nil)
+                    }
+
+                    ForEach(items, id: \.self) { item in
+                        filterButton(label: item, isSelected: selectedValue == item) {
+                            onSelect(item)
+                        }
+                    }
+                }
+                .padding(10)
+            }
+            .frame(width: 550)
+        }
+    }
+
+    private func filterButton(label: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack {
+                Text(label)
+                    .font(.title3)
+
+                Spacer()
+
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .foregroundColor(.blue)
+                        .fontWeight(.bold)
+                }
+            }
+            .padding(.horizontal, 30)
+            .frame(maxWidth: .infinity)
+            .frame(height: 100)
+        }
+        .buttonStyle(.card)
+    }
+
+    private func loadData() async {
+        do {
+            async let fetchedCities = assetProvider.fetchAllCities()
+            async let fetchedYears = assetProvider.fetchAllYears()
+
+            let (cities, years) = try await (fetchedCities, fetchedYears)
+
+            await MainActor.run {
+                availableCities = cities
+                availableYears = years
+                isLoading = false
+            }
+        } catch {
+            await MainActor.run {
+                isLoading = false
+            }
+        }
+    }
+}

--- a/Immich Gallery/Views/Settings/UserDefaults.swift
+++ b/Immich Gallery/Views/Settings/UserDefaults.swift
@@ -83,6 +83,28 @@ extension UserDefaults {
         get { string(forKey: UserDefaultsKeys.allPhotosSortOrder) ?? "desc" }
         set { set(newValue, forKey: UserDefaultsKeys.allPhotosSortOrder) }
     }
+
+    var allPhotosFilterCity: String? {
+        get { string(forKey: UserDefaultsKeys.allPhotosFilterCity) }
+        set {
+            if let value = newValue, !value.isEmpty {
+                set(value, forKey: UserDefaultsKeys.allPhotosFilterCity)
+            } else {
+                removeObject(forKey: UserDefaultsKeys.allPhotosFilterCity)
+            }
+        }
+    }
+
+    var allPhotosFilterYear: Int? {
+        get { object(forKey: UserDefaultsKeys.allPhotosFilterYear) as? Int }
+        set {
+            if let value = newValue {
+                set(value, forKey: UserDefaultsKeys.allPhotosFilterYear)
+            } else {
+                removeObject(forKey: UserDefaultsKeys.allPhotosFilterYear)
+            }
+        }
+    }
     
     var artModeLevel: String {
         get { string(forKey: UserDefaultsKeys.artModeLevel) ?? "off" }

--- a/Immich Gallery/Views/SortSettingsView.swift
+++ b/Immich Gallery/Views/SortSettingsView.swift
@@ -1,0 +1,64 @@
+//
+//  SortSettingsView.swift
+//  Immich Gallery
+//
+
+import SwiftUI
+
+struct SortSettingsView: View {
+    @Binding var sortOrder: String
+    var onApply: () -> Void
+
+    var body: some View {
+        ZStack {
+            Rectangle().fill(.ultraThinMaterial).ignoresSafeArea()
+
+            VStack(spacing: 40) {
+                Text("Sort Options")
+                    .font(.system(size: 60, weight: .bold))
+
+                VStack(alignment: .leading, spacing: 20) {
+                    Text("Sort By")
+                        .font(.headline)
+                        .foregroundColor(.gray)
+
+                    HStack {
+                        Text("Date Taken")
+                        Spacer()
+                        Image(systemName: "checkmark")
+                    }
+                    .frame(width: 500)
+
+                    Text("Order")
+                        .font(.headline)
+                        .foregroundColor(.gray)
+                        .padding(.top, 20)
+
+                    Button(action: { sortOrder = "desc" }) {
+                        HStack {
+                            Text("Newest First")
+                            Spacer()
+                            if sortOrder == "desc" { Image(systemName: "checkmark") }
+                        }
+                        .frame(width: 500)
+                    }
+
+                    Button(action: { sortOrder = "asc" }) {
+                        HStack {
+                            Text("Oldest First")
+                            Spacer()
+                            if sortOrder == "asc" { Image(systemName: "checkmark") }
+                        }
+                        .frame(width: 500)
+                    }
+                }
+
+                Button("Apply") { onApply() }
+                    .buttonStyle(.borderedProminent)
+                    .padding(.top, 40)
+            }
+            .padding(.horizontal, 60)
+            .padding(.vertical, 40)
+        }
+    }
+}

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -32,6 +32,8 @@ struct UserDefaultsKeys {
     static let enableThumbnailAnimation = "enableThumbnailAnimation"
     static let enableSlideshowShuffle = "enableSlideshowShuffle"
     static let allPhotosSortOrder = "allPhotosSortOrder"
+    static let allPhotosFilterCity = "allPhotosFilterCity"
+    static let allPhotosFilterYear = "allPhotosFilterYear"
     static let navigationStyle = "navigationStyle"
     static let enableTopShelf = "enableTopShelf"
     static let topShelfStyle = "topShelfStyle"


### PR DESCRIPTION
What this does:
Adds All Photos filter sheet (City + Year single‑select) and sort sheet (Date Taken asc/desc).
Uses server‑side paging via /api/search/metadata with order, city, and takenAfter/takenBefore.
No client‑side full‑library fetch; initial load remains paged and fast.

What's pending: 
No multi‑select filters (would require client‑side merging/full fetch).
No device filter and no filename sort.
No client‑side sorting/filtering or fetchAllFilteredAndSortedAssets.


Thanks @hwakeman 